### PR TITLE
Send the magic packet 10 times.

### DIFF
--- a/gwakeonlan/functions.py
+++ b/gwakeonlan/functions.py
@@ -69,7 +69,8 @@ def wake_on_lan(mac_address, portnr, destination, settings):
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
     if destination == '255.255.255.255':
         destination = '<broadcast>'
-    sock.sendto(b''.join(data), (destination, portnr))
+    data = b''.join(data)
+    [sock.sendto(data, (destination, portnr)) for _ in range(0, 10)]
 
 
 def readlines(filename, empty_lines=False):


### PR DESCRIPTION
On my hardware/network, gwakeonlan fails where other applications succeed.  
A quick check on wireshark shows that the only difference is that some other apps send the magic packet 10 times.  

This pull-request makes gwakeonlan more reliable on my (and possibly other peoples) setup.  

The machine I am trying to wake is an old, cheap media-centre PC.
```
00:0a.0 Ethernet controller: NVIDIA Corporation MCP79 Ethernet (rev b1)
	Subsystem: ZOTAC International (MCO) Ltd. Device a108
	Control: I/O+ Mem+ BusMaster+ SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
	Status: Cap+ 66MHz+ UDF- FastB2B+ ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
	Latency: 0 (250ns min, 5000ns max)
	Interrupt: pin A routed to IRQ 21
	Region 0: Memory at fae7c000 (32-bit, non-prefetchable) [size=4K]
	Region 1: I/O ports at d080 [size=8]
	Region 2: Memory at fae7e400 (32-bit, non-prefetchable) [size=256]
	Region 3: Memory at fae7e000 (32-bit, non-prefetchable) [size=16]
	Capabilities: [44] Power Management version 2
		Flags: PMEClk- DSI- D1+ D2+ AuxCurrent=0mA PME(D0+,D1+,D2+,D3hot+,D3cold+)
		Status: D0 NoSoftRst- PME-Enable+ DSel=0 DScale=0 PME-
	Kernel driver in use: forcedeth
	Kernel modules: forcedeth
```
