### PR TITLE
Add Appimage support and build workflow

### DIFF
--- a/.github/workflows/appimage-build.yml
+++ b/.github/workflows/appimage-build.yml
@@ -1,0 +1,28 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Gwakeonlan Appimage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2    
+    - name: Build Appimage
+      uses: AppImageCrafters/build-appimage@master
+      with:
+        recipe: "./AppImageBuilder.yml"
+        
+    - name: Save AppImage
+      uses: actions/upload-artifact@master
+      with:
+        name: Gwakeonlan_Appimage
+        path: ./*.AppImage

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.pyc
 *.glade~
 po/gwakeonlan.pot.new
+/appimage-builder-cache
+/AppDir
+.directory
+
+*.AppImage

--- a/AppImageBuilder.yml
+++ b/AppImageBuilder.yml
@@ -1,0 +1,77 @@
+version: 1
+script:
+  # Remove any previous build
+  - rm -rf AppDir | true
+  # Make usr and icons dirs
+  - mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps/
+  - mkdir -p AppDir/usr/share/doc/gwakeonlan
+  - mkdir -p AppDir/usr/share/gwakeonlan
+  # Copy the python application code into the AppDir
+  - cp gwakeonlan.py AppDir/usr/share/gwakeonlan
+  - cp gwakeonlan AppDir/usr/share/gwakeonlan -r
+  - cp ui AppDir/usr/share/gwakeonlan -r
+  - cp data AppDir/usr/share/gwakeonlan -r
+  - cp doc/* AppDir/usr/share/doc/gwakeonlan -r
+  # Copy icon
+  - cp icons/scalable/gwakeonlan.svg AppDir/usr/share/icons/hicolor/scalable/apps/
+
+AppDir:
+  path: ./AppDir
+
+  app_info:
+    id: org.muflone.gwakeonlan
+    name: gwakeonlan
+    icon: gwakeonlan
+    version: 0.7.0
+    exec: usr/bin/python3
+    # Set the application main script path as argument. Use '$@' to forward CLI parameters
+    exec_args: "$APPDIR/usr/share/gwakeonlan/gwakeonlan.py $@"
+
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+
+    include:
+      - python3
+      - python3-gi
+      - python3-xdg
+    exclude: []
+
+  runtime:
+    env:
+      PATH: '${APPDIR}/usr/local/bin:${PATH}'
+      # Set python home
+      # See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONHOME
+      PYTHONHOME: '${APPDIR}/usr'
+      # Path to the site-packages dir or other modules dirs
+      # See https://docs.python.org/3/using/cmdline.html#envvar-PYTHONPATH
+      PYTHONPATH: '${APPDIR}/usr/lib/python3.8/site-packages'
+
+  test:
+    #fedora:
+    #  image: appimagecrafters/tests-env:fedora-30
+    #  command: ./AppRun
+    #  use_host_x: true
+    debian:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+      use_host_x: true
+    arch:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+      use_host_x: true
+    #centos:
+    #  image: appimagecrafters/tests-env:centos-7
+    #  command: ./AppRun
+    #  use_host_x: true
+    ubuntu:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+      use_host_x: true
+
+AppImage:
+  update-information: None
+  sign-key: None
+  arch: x86_64


### PR DESCRIPTION
This PR adds an Appimage build script and a GitHub workflow, which generates the Appimage on each push on master automatically. It is related to #19 

I have tested the resulting Appimage on Debian and Ubuntu.
On Arch based distros I get an deprecated warning on start, which makes the start really slow.

```
(gwakeonlan.py:1976): Gtk-WARNING **: 02:21:34.358: Theme parsing error: gtk.css:69:35: The style property GtkButton:child-displacement-y is deprecated and shouldn't be used anymore. It will be removed in a future version

(gwakeonlan.py:1976): Gtk-WARNING **: 02:21:34.358: Theme parsing error: gtk.css:73:46: The style property GtkScrolledWindow:scrollbars-within-bevel is deprecated and shouldn't be used anymore. It will be removed in a future version
```