### PR TITLE
Add "-" as delimiter.

### DIFF
--- a/gwakeonlan/functions.py
+++ b/gwakeonlan/functions.py
@@ -32,7 +32,7 @@ from gwakeonlan.constants import DIR_UI
 
 def format_mac_address(mac):
     """Return the mac address formatted with colon"""
-    mac = mac.replace(':', '').replace('.', '')
+    mac = mac.replace(':', '').replace('.', '').replace('-', '')
     return ':'.join([mac[i:i+2] for i in range(0, len(mac), 2)]).upper()
 
 

--- a/gwakeonlan/ui/detail.py
+++ b/gwakeonlan/ui/detail.py
@@ -62,7 +62,7 @@ class UIDetail(UIBase):
             if response == Gtk.ResponseType.OK:
                 # Check values for valid response
                 err_msg = ''
-                mac = self.get_mac_address().replace(':', '').replace('.', '')
+                mac = self.get_mac_address().replace(':', '').replace('.', '').replace('-','')
                 if not self.get_machine_name():
                     err_msg = _('Missing machine name')
                     self.ui.text_machine_name.grab_focus()


### PR DESCRIPTION
This commit add a functionality to replace "-" to "" inside MAC address. 

Windows uses "-" as MAC Address delimiter instead of ":". Thus, it is nice to accept it to wake up a remote Windows machine.

Tested and confirmed both ':' and '-' work as delimiter. 